### PR TITLE
disable calendar apply button when no date is selected

### DIFF
--- a/app/src/components/CalendarDatePicker/Pure.jsx
+++ b/app/src/components/CalendarDatePicker/Pure.jsx
@@ -141,6 +141,7 @@ export default class CalendarDatePicker extends Component {
                     size={'small'}
                     onClick={this.handleCalendarApplyOnClick}
                     children={'Apply'}
+                    disabled={(!this.props.from || !this.props.enteredTo || !this.props.to)}
                   />
               </ButtonsWrapper>
             </div>


### PR DESCRIPTION
Disable the APPLY button after reset date so that only when a date is selected can the apply button function as usual. 

This is to prevent invalid date selection when a use clicks reset and apply immediately. 