### PR TITLE
store previous selected time and use it upon cancel

### DIFF
--- a/app/src/components/BikeUsageMainSearch/Pure.jsx
+++ b/app/src/components/BikeUsageMainSearch/Pure.jsx
@@ -135,7 +135,9 @@ const BikeUsageMainSearch = ({
   currentGraphInputValue,
   toggleResultsWrapperVisibilityAction,
   resultsWrapperVisibilityStatus,
-  fetchDistrictSelectedActionSaga
+  fetchDistrictSelectedActionSaga,
+  storeTimeStateAction,
+  displayPreviousTimeAction
 }) => {
   const handleTabChange = v => changeToggledTabAction(v)
   const openDatePicker = v => {
@@ -149,6 +151,7 @@ const BikeUsageMainSearch = ({
   const openTimePicker = v => {
     if (!isAnyWidgetOpenCurrently) {
       showTimePickerAction(v)
+      storeTimeStateAction()
       toggleWidgetOpenStatusAction(true)
     } else {
       return null
@@ -276,6 +279,7 @@ const BikeUsageMainSearch = ({
                 selectTimeFromAction={selectTimeFromAction}
                 selectTimeToAction={selectTimeToAction}
                 hideTimePickerAction={hideTimePickerAction}
+                displayPreviousTimeAction={displayPreviousTimeAction}
                 toggleWidgetOpenStatusAction={toggleWidgetOpenStatusAction}
                 currentMapBounds={currentMapBounds}
                 getHeatmapPointsActionSaga={getHeatmapPointsActionSaga}

--- a/app/src/components/BikeUsageMainSearch/index.js
+++ b/app/src/components/BikeUsageMainSearch/index.js
@@ -35,7 +35,9 @@ import {
   updateGraphSearchInputValueAction,
   toggleResultsWrapperVisibilityAction,
   fetchDistrictSelectedActionSaga,
-  computeAggregatedTopLocations
+  computeAggregatedTopLocations,
+  storeTimeStateAction,
+  displayPreviousTimeAction
 } from 'models/dashboard'
 
 // s function
@@ -60,6 +62,9 @@ const s = state => ({
   timeFromArray: state.dashboard.timeFromArray,
   timeToArray: state.dashboard.timeToArray,
   timeTagName: state.dashboard.timeTagName,
+  previousTimeFrom: state.dashboard.previousTimeFrom,
+  previousTimeTo: state.dashboard.previousTimeTo,
+  previousTimeTag: state.dashboard.previousTimeTagName,
   dropDownDisplayStatus: state.dashboard.dropDownDisplayStatus,
   currentDropDownDisplayValue: state.dashboard.currentDropDownDisplayValue,
   bikeUsageTopLocationsArray: computeAggregatedTopLocations(state),
@@ -103,7 +108,9 @@ const d = dispatch => ({
   updateGraphSelectedDistrictAction: bindActionCreators(updateGraphSelectedDistrictAction, dispatch),
   updateGraphSearchInputValueAction: bindActionCreators(updateGraphSearchInputValueAction, dispatch),
   toggleResultsWrapperVisibilityAction: bindActionCreators(toggleResultsWrapperVisibilityAction, dispatch),
-  fetchDistrictSelectedActionSaga: bindActionCreators(fetchDistrictSelectedActionSaga, dispatch)
+  fetchDistrictSelectedActionSaga: bindActionCreators(fetchDistrictSelectedActionSaga, dispatch),
+  storeTimeStateAction: bindActionCreators(storeTimeStateAction, dispatch),
+  displayPreviousTimeAction: bindActionCreators(displayPreviousTimeAction, dispatch)
 })
 
 export default withRouter(connect(s, d)(Pure))

--- a/app/src/components/TimePicker/Pure.jsx
+++ b/app/src/components/TimePicker/Pure.jsx
@@ -63,6 +63,7 @@ const TimePicker = ({
   filterTimeToArrayAction,
   filterTimeFromArrayAction,
   getTimeTagAction,
+  displayPreviousTimeAction,
   toggleWidgetOpenStatusAction,
   fetchSagaAction,
   currentMapBounds,
@@ -126,6 +127,7 @@ const TimePicker = ({
   const handleCancelOnClick = () => {
     toggleWidgetOpenStatusAction(false)
     hideTimePickerAction()
+    displayPreviousTimeAction()
   }
 
   return (

--- a/app/src/components/WeatherEffect/Pure.jsx
+++ b/app/src/components/WeatherEffect/Pure.jsx
@@ -102,7 +102,9 @@ const WeatherEffect = ({
   isAnyWidgetOpenCurrently,
   totalBikeUsageAndWeatherActionSaga,
   aggregatedBikeWeather,
-  currentTab
+  currentTab,
+  storeTimeStateAction,
+  displayPreviousTimeAction
 }) => {
   const handleWeatherTab = val => changeWeatherTabAction(val)
 
@@ -117,6 +119,7 @@ const WeatherEffect = ({
   const openTimePicker = v => {
     if (!isAnyWidgetOpenCurrently) {
       showTimePickerAction(v)
+      storeTimeStateAction()
       toggleWidgetOpenStatusAction(true)
     } else {
       return null
@@ -182,6 +185,7 @@ const WeatherEffect = ({
               timeFromArray={timeFromArray}
               timeFrom={timeFrom}
               timeTo={timeTo}
+              displayPreviousTimeAction={displayPreviousTimeAction}
               selectTimeFromAction={selectTimeFromAction}
               selectTimeToAction={selectTimeToAction}
               hideTimePickerAction={hideTimePickerAction}

--- a/app/src/components/WeatherEffect/index.js
+++ b/app/src/components/WeatherEffect/index.js
@@ -20,7 +20,9 @@ import {
   clickDateFromWeatherAction,
   clickDateToWeatherAction,
   totalBikeUsageAndWeatherActionSaga,
-  computeAggregatedBikeWeather
+  computeAggregatedBikeWeather,
+  storeTimeStateAction,
+  displayPreviousTimeAction
 } from 'models/dashboard'
 
 // s function
@@ -38,6 +40,9 @@ const s = state => ({
   timeFromArray: state.dashboard.timeFromArray,
   timeToArray: state.dashboard.timeToArray,
   timeTagName: state.dashboard.timeTagName,
+  previousTimeFrom: state.dashboard.previousTimeFrom,
+  previousTimeTo: state.dashboard.previousTimeTo,
+  previousTimeTag: state.dashboard.previousTimeTagName,
   isAnyWidgetOpenCurrently: state.dashboard.isAnyWidgetOpenCurrently,
   fromDateWeather: state.dashboard.fromDateWeather,
   toDateWeather: state.dashboard.toDateWeather,
@@ -63,7 +68,9 @@ const d = dispatch => ({
   resetWeatherCalendarAction: bindActionCreators(resetWeatherCalendarAction, dispatch),
   clickDateFromWeatherAction: bindActionCreators(clickDateFromWeatherAction, dispatch),
   clickDateToWeatherAction: bindActionCreators(clickDateToWeatherAction, dispatch),
-  totalBikeUsageAndWeatherActionSaga: bindActionCreators(totalBikeUsageAndWeatherActionSaga, dispatch)
+  totalBikeUsageAndWeatherActionSaga: bindActionCreators(totalBikeUsageAndWeatherActionSaga, dispatch),
+  storeTimeStateAction: bindActionCreators(storeTimeStateAction, dispatch),
+  displayPreviousTimeAction: bindActionCreators(displayPreviousTimeAction, dispatch)
 })
 
 export default withRouter(connect(s, d)(Pure))

--- a/app/src/models/dashboard.js
+++ b/app/src/models/dashboard.js
@@ -73,6 +73,8 @@ export const filterTimeFromArrayAction = createAction(
   `${TIME} FILTER_TIME_FROM_ARRAY`
 )
 export const getTimeTagAction = createAction(`${TIME} TIME_TAG_SELECTED`)
+export const storeTimeStateAction = createAction(`${TIME} STORE_TIME_STATE`)
+export const displayPreviousTimeAction = createAction(`${TIME} DISPLAY_PREVIOUS_TIME_STATE`)
 
 // Calendar + Time Actions
 export const toggleWidgetOpenStatusAction = createAction(
@@ -398,6 +400,30 @@ const getTimeTag = (state, time) => ({
   timeTo: time[1].timeTo
 })
 
+const storeTimeState = (state) => {
+  const previousTimeFrom = state.timeFrom
+  const previousTimeTo = state.timeTo
+  const previousTimeTagName = state.timeTagName
+  return {
+    ...state,
+    previousTimeFrom: previousTimeFrom,
+    previousTimeTo: previousTimeTo,
+    previousTimeTag: previousTimeTagName
+  }
+}
+
+const displayPreviousTimeState = state => {
+  const timeFrom = state.previousTimeFrom
+  const timeTo = state.previousTimeTo
+  const timeTagName = state.previousTimeTag
+  return {
+    ...state,
+    timeFrom: timeFrom,
+    timeTo: timeTo,
+    timeTagName: timeTagName
+  }
+}
+
 // Graph
 const bikeUsageTopLocations = (state, data) => {
   return ({
@@ -500,6 +526,8 @@ export const dashboard = {
   [filterTimeToArrayAction]: filterTimeToArray,
   [filterTimeFromArrayAction]: filterTimeFromArray,
   [getTimeTagAction]: getTimeTag,
+  [storeTimeStateAction]: storeTimeState,
+  [displayPreviousTimeAction]: displayPreviousTimeState,
   [toggleDropdownVisibilityAction]: toggleDropdownVisibility,
   [updateDropDownDisplayValueAction]: updateDropDownDisplayValue,
   [getBikeUsageTopLocationsActionSuccess]: bikeUsageTopLocations,


### PR DESCRIPTION
In Time Picker, when a new timing is selected and upon clicking cancel, we will restore time back to its previous selected time state.