### PR TITLE
Bugfix/graph search results box

### DIFF
--- a/app/src/components/BikeUsageMainSearch/Pure.jsx
+++ b/app/src/components/BikeUsageMainSearch/Pure.jsx
@@ -133,9 +133,13 @@ const BikeUsageMainSearch = ({
   graphSelectedDistrict,
   updateGraphSearchInputValueAction,
   currentGraphInputValue,
+  updatePreviousGraphSearchInputValueAction,
+  previousGraphInputValue,
   toggleResultsWrapperVisibilityAction,
   resultsWrapperVisibilityStatus,
-  fetchDistrictSelectedActionSaga
+  fetchDistrictSelectedActionSaga,
+  updateMouseOverStatusAction,
+  mouseOverStatus
 }) => {
   const handleTabChange = v => changeToggledTabAction(v)
   const openDatePicker = v => {
@@ -215,10 +219,14 @@ const BikeUsageMainSearch = ({
                 graphSelectedDistrict={graphSelectedDistrict}
                 updateGraphSearchInputValueAction={updateGraphSearchInputValueAction}
                 currentGraphInputValue={currentGraphInputValue}
+                updatePreviousGraphSearchInputValueAction={updatePreviousGraphSearchInputValueAction}
+                previousGraphInputValue={previousGraphInputValue}
                 toggleResultsWrapperVisibilityAction={toggleResultsWrapperVisibilityAction}
                 resultsWrapperVisibilityStatus={resultsWrapperVisibilityStatus}
                 fetchDistrictSelectedActionSaga={fetchDistrictSelectedActionSaga}
                 fetchSagaAction={getBikeUsageTopLocationsActionSaga}
+                updateMouseOverStatusAction={updateMouseOverStatusAction}
+                mouseOverStatus={mouseOverStatus}
               />
             </SubHeader>
           </SearchBoxDiv>

--- a/app/src/components/BikeUsageMainSearch/index.js
+++ b/app/src/components/BikeUsageMainSearch/index.js
@@ -33,9 +33,11 @@ import {
   updateGraphSearchResultsAction,
   updateGraphSelectedDistrictAction,
   updateGraphSearchInputValueAction,
+  updatePreviousGraphSearchInputValueAction,
   toggleResultsWrapperVisibilityAction,
   fetchDistrictSelectedActionSaga,
-  computeAggregatedTopLocations
+  computeAggregatedTopLocations,
+  updateMouseOverStatusAction
 } from 'models/dashboard'
 
 // s function
@@ -69,8 +71,10 @@ const s = state => ({
   graphSearchResults: state.dashboard.graphSearchResults,
   graphSelectedDistrict: state.dashboard.graphSelectedDistrict,
   currentGraphInputValue: state.dashboard.currentGraphInputValue,
+  previousGraphInputValue: state.dashboard.previousGraphInputValue,
   resultsWrapperVisibilityStatus: state.dashboard.resultsWrapperVisibilityStatus,
-  loadingBarStatus: state.dashboard.loadingBarStatus
+  loadingBarStatus: state.dashboard.loadingBarStatus,
+  mouseOverStatus: state.dashboard.mouseOverStatus
 })
 
 const d = dispatch => ({
@@ -102,8 +106,10 @@ const d = dispatch => ({
   updateGraphSearchResultsAction: bindActionCreators(updateGraphSearchResultsAction, dispatch),
   updateGraphSelectedDistrictAction: bindActionCreators(updateGraphSelectedDistrictAction, dispatch),
   updateGraphSearchInputValueAction: bindActionCreators(updateGraphSearchInputValueAction, dispatch),
+  updatePreviousGraphSearchInputValueAction: bindActionCreators(updatePreviousGraphSearchInputValueAction, dispatch),
   toggleResultsWrapperVisibilityAction: bindActionCreators(toggleResultsWrapperVisibilityAction, dispatch),
-  fetchDistrictSelectedActionSaga: bindActionCreators(fetchDistrictSelectedActionSaga, dispatch)
+  fetchDistrictSelectedActionSaga: bindActionCreators(fetchDistrictSelectedActionSaga, dispatch),
+  updateMouseOverStatusAction: bindActionCreators(updateMouseOverStatusAction, dispatch)
 })
 
 export default withRouter(connect(s, d)(Pure))

--- a/app/src/components/SearchBar/Pure.jsx
+++ b/app/src/components/SearchBar/Pure.jsx
@@ -91,9 +91,8 @@ const SearchBar = props => {
   const outsideSearchClickEventListener = event => {
     const id = event.target.id || ''
     if (!id.includes('searchItem') && !id.includes('graph-search') && resultsWrapperVisibilityStatus) {
-      removeClickListener()
-      updateGraphSearchInputValueAction(previousGraphInputValue)
       toggleResultsWrapperVisibilityAction(false)
+      removeClickListener()
     }
   }
   const removeClickListener = () => document.removeEventListener('click', outsideSearchClickEventListener)
@@ -114,10 +113,15 @@ const SearchBar = props => {
     }
   }
   const handleHoverAndMouseOut = (e) => {
-    if (id === 'graph-search')
-    e.type === 'mouseover'
-      ? updateMouseOverStatusAction(true)
-      : updateMouseOverStatusAction(false) && e.target.blur()
+    if (id === 'graph-search') {
+      if (e.type === 'mouseover') updateMouseOverStatusAction(true)
+      else {
+        updateMouseOverStatusAction(false)
+        e.target.blur()
+        changeInputFocusAction('blur')
+      }
+    }
+
   }
   const handleSearchBarOnChange = (e) => {
     if (currentToggledTab === 'GRAPH') {
@@ -133,6 +137,7 @@ const SearchBar = props => {
   }
   const handleSearchItemOnClick = (e) => {
     updateGraphSearchInputValueAction(e.target.innerHTML)
+    updatePreviousGraphSearchInputValueAction(e.target.innerHTML)
     updateGraphSelectedDistrictAction(e.target.innerHTML)
     toggleResultsWrapperVisibilityAction(false)
     e.target.innerHTML !== 'All of London' ? fetchDistrictSelectedActionSaga() : fetchSagaAction()

--- a/app/src/models/dashboard.js
+++ b/app/src/models/dashboard.js
@@ -122,9 +122,11 @@ export const showErrorAction = createAction(`${GRAPH} SHOW_ERROR_MESSAGE`)
 export const updateGraphSearchResultsAction = createAction(`${GRAPH} UPDATE SEARCH RESULTS ARRAY`)
 export const updateGraphSelectedDistrictAction = createAction(`${GRAPH} UPDATE SELECTED DISTRICT`)
 export const updateGraphSearchInputValueAction = createAction(`${GRAPH} UPDATE INPUT VALUE`)
+export const updatePreviousGraphSearchInputValueAction = createAction(`${GRAPH} UPDATE PREVIOUS INPUT VALUE`)
 export const toggleResultsWrapperVisibilityAction = createAction(`${GRAPH} TOGGLE HIDE SHOW RESULTS WRAPPER`)
 export const fetchDistrictsActionSuccess = createAction(`${GRAPH} GET_BIKE_TOP_DISTRICTS_SUCCESS`)
 export const fetchDistrictsActionFail = createAction(`${GRAPH} GET_BIKE_TOP_DISTRICTS_FAIL`)
+export const updateMouseOverStatusAction = createAction(`${GRAPH} UPDATE MOUSE OVER STATUS`)
 
 /** --------------------------------------------------
  *
@@ -427,10 +429,24 @@ const updateGraphSearchInputValue = (state, value) => {
   })
 }
 
+const updatePreviousGraphSearchInputValue = (state, value) => {
+  return ({
+    ...state,
+    previousGraphInputValue: value
+  })
+}
+
 const toggleResultsWrapperVisibility = (state, bool) => {
   return ({
     ...state,
     resultsWrapperVisibilityStatus: bool
+  })
+}
+
+const updateMouseOverStatus = (state, bool) => {
+  return ({
+    ...state,
+    mouseOverStatus: bool
   })
 }
 
@@ -514,9 +530,11 @@ export const dashboard = {
   [updateGraphSearchResultsAction]: updateGraphSearchResults,
   [updateGraphSelectedDistrictAction]: updateGraphSelectedDistrict,
   [updateGraphSearchInputValueAction]: updateGraphSearchInputValue,
+  [updatePreviousGraphSearchInputValueAction]: updatePreviousGraphSearchInputValue,
   [toggleResultsWrapperVisibilityAction]: toggleResultsWrapperVisibility,
   [getTotalBikeUsageWeatherSuccess]: totalBikeUsageAndWeather,
-  [fetchDistrictsActionSuccess]: bikeUsageTopLocations
+  [fetchDistrictsActionSuccess]: bikeUsageTopLocations,
+  [updateMouseOverStatusAction] : updateMouseOverStatus
 }
 
 /** --------------------------------------------------
@@ -575,9 +593,11 @@ export const dashboardInitialState = {
   graphSearchResults: [],
   graphSelectedDistrict: 'All of London',
   currentGraphInputValue: '',
+  previousGraphInputValue: '',
   resultsWrapperVisibilityStatus: false,
   totalBikeUsage: [],
-  weather: {}
+  weather: {},
+  mouseOverStatus: false
 }
 
 export default createReducer(dashboard, dashboardInitialState)


### PR DESCRIPTION
Focused
- When focused and input value empty, results div will not show
- When focused and input value is not empty, results div will show
- When input value is not empty and search filter returns empty array, 'No search results to display' is shown in search results wrapper

MouseOut
- When mouseout from input field, action is fired for mouseOverStatus and blur event is also triggered, so that user does not have to click on a search result item twice (one to remove focus from input field and one to select search result item)

Click Listener
- When user clicks outside search field or search results box, search wrapper will be hidden

Search Districts
- Previously, search algorithm was not comparing the correct values, as the target value compared was the previously entered value, have fixed it