### PR TITLE
fix public holidays

### DIFF
--- a/app/src/constants/index.js
+++ b/app/src/constants/index.js
@@ -5,8 +5,8 @@ export const publicHolidaysLondon = {
   'Christmas Day 2017': new Date('2017-12-25'),
   'Boxing Day 2017': new Date('2017-12-26'),
   'New Year\'s Day 2018': new Date('2018-01-01'),
-  'Good Friday 2018': new Date('2018-04-22'),
-  'Easter Monday 2018': new Date('2018-04-19')
+  'Good Friday 2018': new Date('2018-03-30'),
+  'Easter Monday 2018': new Date('2018-04-02')
 }
 
 export const timeFilters = {


### PR DESCRIPTION
Document stated wrong Easter and Good Friday date for 2018: https://docs.google.com/document/d/1TvaTrWbAVg6ZHuo0066Yb5WUzAzYC7IOVKNqXzBDBVw/edit

Fix it to:
Easter 2018 - 30 March 2018
Good Friday 2018 - 2nd April 2018
