### PR TITLE
disable unsubscribe button

### DIFF
--- a/app/src/components/EmailSubscribe/Pure.jsx
+++ b/app/src/components/EmailSubscribe/Pure.jsx
@@ -67,6 +67,7 @@ const EmailSubscribe = ({isEmailSubscribed, isEmailSubscribedAction, handleInput
             style={unsubscribe}
             type='submit'
             value='Unsubscribe'
+            disabled={isEmailSubscribed}
           />)
           : (<input
             style={subscribe}


### PR DESCRIPTION
We disable the `unsubscribe` button since there is not functionality to unsubscribe the user. 